### PR TITLE
Change configuration to collect coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	collectCoverage: true,
 	globals: {
 		'ts-jest': {
 			tsConfigFile: 'tsconfig.json'


### PR DESCRIPTION
You'll need to collect code coverage for the Jest extension to have coverage data to show.

This resolves jest-community/vscode-jest#333. 